### PR TITLE
fix: structured ConfirmationMessage schema rejected by provider

### DIFF
--- a/src/agents/messages.py
+++ b/src/agents/messages.py
@@ -1,4 +1,5 @@
 from autogen_agentchat.messages import BaseTextChatMessage
+from pydantic import BaseModel, ConfigDict
 
 
 class UserMessage(BaseTextChatMessage):
@@ -125,6 +126,22 @@ class RecursionCreateMessage(BaseTextChatMessage):
 
 class ConfirmationMessage(BaseTextChatMessage):
     """Used by a system to confirm an action has been completed."""
+
+    content: str
+    is_error: bool
+
+
+class ConfirmationResponse(BaseModel):
+    """Structured-output payload for providers.
+
+    We intentionally avoid inheriting from BaseTextChatMessage because upstream
+    includes a free-form `metadata` object that some OpenAI-compatible providers
+    reject unless every object schema sets `additionalProperties: false`.
+
+    Using a plain BaseModel with `extra='forbid'` yields a stricter JSON schema.
+    """
+
+    model_config = ConfigDict(extra="forbid")
 
     content: str
     is_error: bool

--- a/src/agents/system5.py
+++ b/src/agents/system5.py
@@ -7,6 +7,7 @@ from autogen_core.tools import FunctionTool
 from src.agents.messages import (
     CapabilityGapMessage,
     ConfirmationMessage,
+    ConfirmationResponse,
     InternalErrorMessage,
     PolicySuggestionMessage,
     TaskReviewMessage,
@@ -90,7 +91,7 @@ class System5(SystemBase):
             [message],
             context,
             message_specific_prompts,
-            output_content_type=ConfirmationMessage,
+            output_content_type=ConfirmationResponse,
         )
 
         return self._get_structured_message(response, ConfirmationMessage)
@@ -148,7 +149,7 @@ class System5(SystemBase):
                 [message],
                 context,
                 message_specific_prompts,
-                output_content_type=ConfirmationMessage,
+                output_content_type=ConfirmationResponse,
             )
         except Exception as exc:
             return ConfirmationMessage(
@@ -161,7 +162,14 @@ class System5(SystemBase):
             )
 
         try:
-            return self._get_structured_message(response, ConfirmationMessage)
+            parsed: ConfirmationResponse = self._get_structured_message(
+                response, ConfirmationResponse
+            )
+            return ConfirmationMessage(
+                content=parsed.content,
+                is_error=parsed.is_error,
+                source=self.name,
+            )
         except Exception:
             # Back-compat / testing: allow plain-text confirmations when structured output
             # is not available (e.g., mocked TaskResult in unit tests).
@@ -226,10 +234,17 @@ class System5(SystemBase):
             [message],
             context,
             message_specific_prompts,
-            output_content_type=ConfirmationMessage,
+            output_content_type=ConfirmationResponse,
         )
 
-        return self._get_structured_message(response, ConfirmationMessage)
+        parsed: ConfirmationResponse = self._get_structured_message(
+            response, ConfirmationResponse
+        )
+        return ConfirmationMessage(
+            content=parsed.content,
+            is_error=parsed.is_error,
+            source=self.name,
+        )
 
     @message_handler
     async def handle_policy_suggestion_message(
@@ -424,10 +439,17 @@ class System5(SystemBase):
             [message],
             context,
             message_specific_prompts,
-            output_content_type=ConfirmationMessage,
+            output_content_type=ConfirmationResponse,
         )
 
-        return self._get_structured_message(response, ConfirmationMessage)
+        parsed: ConfirmationResponse = self._get_structured_message(
+            response, ConfirmationResponse
+        )
+        return ConfirmationMessage(
+            content=parsed.content,
+            is_error=parsed.is_error,
+            source=self.name,
+        )
 
     @message_handler
     async def handle_research_review_message(
@@ -462,10 +484,17 @@ class System5(SystemBase):
             [message],
             context,
             message_specific_prompts,
-            output_content_type=ConfirmationMessage,
+            output_content_type=ConfirmationResponse,
         )
 
-        return self._get_structured_message(response, ConfirmationMessage)
+        parsed: ConfirmationResponse = self._get_structured_message(
+            response, ConfirmationResponse
+        )
+        return ConfirmationMessage(
+            content=parsed.content,
+            is_error=parsed.is_error,
+            source=self.name,
+        )
 
     @message_handler
     async def handle_team_envelope_update_message(

--- a/tests/agents/test_confirmation_response_schema.py
+++ b/tests/agents/test_confirmation_response_schema.py
@@ -1,0 +1,12 @@
+from src.agents.messages import ConfirmationResponse
+
+
+def test_confirmation_response_schema_is_strict() -> None:
+    schema = ConfirmationResponse.model_json_schema()
+
+    # Pydantic v2 uses JSON Schema Draft 2020-12 style.
+    # With extra='forbid', top-level should forbid additional properties.
+    assert schema.get("additionalProperties") is False
+
+    props = schema.get("properties", {})
+    assert set(props.keys()) == {"content", "is_error"}


### PR DESCRIPTION
Fixes #38.

Some OpenAI-compatible providers reject the JSON schema generated for `ConfirmationMessage` because upstream `BaseTextChatMessage` includes a free-form `metadata` object that lacks `additionalProperties: false`.

This PR:
- Adds a provider-facing `ConfirmationResponse` (plain pydantic `BaseModel`, `extra='forbid'`).
- Uses `ConfirmationResponse` for System5 structured outputs and converts back to `ConfirmationMessage` for internal messaging.
- Adds a regression test asserting the schema is strict (no extra fields).

Tests:
- `bash scripts/usability.sh`
- `bash scripts/nightly-cyberneticagents.sh`